### PR TITLE
Adiciona suporte ao Travis (http://travis-ci.org).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+script: phpunit -c tests/phpunit.xml --verbose --coverage-text tests/
+
+php:
+  - 5.3
+  - 5.4
+
+before_script:
+  - "composer install -v"
+
+after_script:
+  - "phpunit -c tests/phpunit.xml --testdox tests/"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+COMPOSER = php composer.phar
+VENDOR_DIR = vendor
+PHPUNIT = bin/phpunit
+PHPUNIT_XML = tests/phpunit.xml
+CURRENT_BRANCH := $(shell git branch | grep '*' | cut -d ' ' -f 2)
+BRANCHES=`git branch | grep -v "*" | tr "\\n" " "`
+
+.check-composer:
+	@echo "Checking if Composer is installed..."
+	@test -f composer.phar || curl -s http://getcomposer.org/installer | php;
+
+.check-installation: .check-composer
+	@echo "Checking for vendor directory..."
+	@test -d $(VENDOR_DIR) || make install
+
+clean:
+	@echo "Removing Composer..."
+	rm -f composer.phar
+	rm -rf vendor
+
+test: .check-installation
+	$(PHPUNIT) -c $(PHPUNIT_XML) tests/
+
+test-branches:
+	@echo "Current branch: $(CURRENT_BRANCH)";
+	@for BRANCH in $(BRANCHES); do \
+		echo "------------------------------------------------------------" \
+		git checkout $$BRANCH; \
+		test -f Makefile && make test || git checkout $(CURRENT_BRANCH); \
+	done;
+	git checkout $(CURRENT_BRANCH);
+
+testdox: .check-installation
+	$(PHPUNIT) -c $(PHPUNIT_XML) --testdox tests/
+
+coverage: .check-installation
+	$(PHPUNIT) -c $(PHPUNIT_XML) --coverage-text tests/	
+
+install: clean .check-installation
+	@echo "Executing a composer installation of development dependencies.."
+	$(COMPOSER) install --dev
+
+update: .check-installation
+	@echo "Executing a composer update of development dependencies.."
+	$(COMPOSER) update --dev
+
+.PHONY: test clean

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Oportunidades
+Oportunidades [![Build Status](https://travis-ci.org/iMastersDev/oportunidades.png?branch=travis,develop,master)](https://travis-ci.org/iMastersDev/oportunidades?branch=travis,develop,master)
 =============
 
 Plataforma para organização de oportunidades de trabalho em PHP.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "imasters/ophportunidades",
-    "require": {
+    "require-dev": {
         "phpunit/phpunit": "3.7@stable"
     },
     "minimum-stability": "alpha",


### PR DESCRIPTION
O PHPUnit foi marcado no `composer.json` como pacote de desenvolv.,
ou seja, para instalá-lo agora: `composer.phar install --dev`.

Apanhei pra fazer o PHPUnit do Composer funcionar no Travis e
desisti.
