### PR TITLE
Cria phpunit.xml.dist para ficar na raiz do projeto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 composer.phar
 composer.lock
 .vagrant
+phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-script: phpunit -c tests/phpunit.xml --verbose --coverage-text tests/
+script: phpunit --verbose --coverage-text
 
 php:
   - 5.3
@@ -9,4 +9,4 @@ before_script:
   - "composer install -v"
 
 after_script:
-  - "phpunit -c tests/phpunit.xml --testdox tests/"
+  - "phpunit --testdox"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ COMPOSER = php composer.phar
 VENDOR_DIR = vendor
 BIN_DIR = bin
 PHPUNIT = $(BIN_DIR)/phpunit
-PHPUNIT_XML = tests/phpunit.xml
 PHPCS = $(BIN_DIR)/phpcs
 PHPCS_STANDARD = PSR2
 CURRENT_BRANCH := $(shell git branch | grep '*' | cut -d ' ' -f 2)
@@ -33,7 +32,7 @@ clean:
 	rm -f bin/phpcs
 
 test: .check-installation
-	$(PHPUNIT) -c $(PHPUNIT_XML) tests/
+	$(PHPUNIT)
 
 test-branches: .check-no-changes
 	@echo "Current branch: $(CURRENT_BRANCH)";
@@ -41,10 +40,10 @@ test-branches: .check-no-changes
 	@$(foreach branch,$(BRANCHES), git checkout $(branch) & test -f Makefile & make test)
 
 testdox: .check-installation
-	$(PHPUNIT) -c $(PHPUNIT_XML) --testdox tests/
+	$(PHPUNIT) --testdox
 
 coverage: .check-installation
-	$(PHPUNIT) -c $(PHPUNIT_XML) --coverage-text tests/	
+	$(PHPUNIT) --coverage-text
 
 install: clean .check-composer
 	@echo "Executing a composer installation of development dependencies.."

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="../public/bootstrap.php"
+         bootstrap="public/bootstrap.php"
          cacheTokens="true"
          colors="false"
          convertErrorsToExceptions="true"
@@ -10,9 +10,14 @@
          stopOnFailure="false"
          syntaxCheck="false"
          verbose="false">
+    <testsuites>
+        <testsuite name="PHPUnit">
+            <directory>tests/Ophportunidades</directory>
+        </testsuite>
+    </testsuites>
     <filter>
         <whitelist>
-            <directory>../src/Ophportunidades</directory>
+            <directory>src/Ophportunidades</directory>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
Resolve dois problemas:
- permitir rodar o comando `phpunit` da raíz do projeto sem precisar do
  parâmetro `-c`
- permitir que alguém use um `phpunit.xml` específico quando necessário,
  sobrescrevendo o `phpunit.xml.dist` (
  http://phpunit.de/manual/3.7/en/textui.html e
  http://www.testically.org/2010/08/24/best-practice-how-to-ship-phpunit-configuration/)
